### PR TITLE
fix(cli): display usage

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,9 @@ func extractPayloadBin(filename string) string {
 
 func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
+	if len(os.Args) < 2 {
+		usage()
+	}
 	filename := os.Args[1]
 
 	if _, err := os.Stat(filename); os.IsNotExist(err) {


### PR DESCRIPTION
- fixes index out of range with no filename supplied
- looks like this was intended but never implemented