### PR TITLE
chore(ci): use fedora:33 instead of fedora:latest

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
-    container: fedora:latest
+    container: fedora:33
 
     steps:
       - name: Install dependencies


### PR DESCRIPTION
Apparently F34 became `latest` couple hours ago and
thus Darwin builds fail now.