### PR TITLE
improve readability of partition(s) listing

### DIFF
--- a/payload.go
+++ b/payload.go
@@ -191,10 +191,10 @@ func (p *Payload) Init() error {
 
 	fmt.Println("Found partitions:")
 	for i, partition := range p.deltaArchiveManifest.Partitions {
-		fmt.Printf("%s (%s)", partition.GetPartitionName(), humanize.Bytes(*partition.GetNewPartitionInfo().Size))
+		fmt.Printf(" %s (%s)", partition.GetPartitionName(), humanize.Bytes(*partition.GetNewPartitionInfo().Size))
 
 		if i < len(deltaArchiveManifest.Partitions)-1 {
-			fmt.Printf(", ")
+			fmt.Printf(",\n")
 		} else {
 			fmt.Printf("\n")
 		}


### PR DESCRIPTION
a small improvement:

listing the partition contents vertically instead of horizontally, and having an additional space character at the start of the string should improve readability in the terminal