### PR TITLE
read payload directly from zip offset

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"flag"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"runtime"
@@ -12,36 +11,29 @@ import (
 	"time"
 )
 
-func extractPayloadBin(filename string) string {
+func findPayloadBinOffset(filename string) (string, int64, error) {
 	zipReader, err := zip.OpenReader(filename)
 	if err != nil {
-		log.Fatalf("Not a valid zip archive: %s\n", filename)
+		return "", 0, fmt.Errorf("not a valid zip archive: %s", filename)
 	}
 	defer zipReader.Close()
 
 	for _, file := range zipReader.Reader.File {
 		if file.Name == "payload.bin" && file.UncompressedSize64 > 0 {
-			zippedFile, err := file.Open()
-			if err != nil {
-				log.Fatalf("Failed to read zipped file: %s\n", file.Name)
+			if file.Method != zip.Store {
+				return "", 0, fmt.Errorf("payload.bin is compressed (method %d), expected STORE (0)", file.Method)
 			}
 
-			tempfile, err := os.CreateTemp(os.TempDir(), "payload_*.bin")
+			offset, err := file.DataOffset()
 			if err != nil {
-				log.Fatalf("Failed to create a temp file located at %s\n", tempfile.Name())
-			}
-			defer tempfile.Close()
-
-			_, err = io.Copy(tempfile, zippedFile)
-			if err != nil {
-				log.Fatal(err)
+				return "", 0, fmt.Errorf("failed to get data offset: %w", err)
 			}
 
-			return tempfile.Name()
+			return filename, offset, nil
 		}
 	}
 
-	return ""
+	return "", 0, fmt.Errorf("payload.bin not found in ZIP")
 }
 
 func main() {
@@ -73,19 +65,23 @@ func main() {
 		log.Fatalf("File does not exist: %s\n", filename)
 	}
 
-	payloadBin := filename
+	payloadFile := filename
+	payloadOffset := int64(0)
+	
 	if strings.HasSuffix(filename, ".zip") {
-		fmt.Println("Please wait while extracting payload.bin from the archive.")
-		payloadBin = extractPayloadBin(filename)
-		if payloadBin == "" {
-			log.Fatal("Failed to extract payload.bin from the archive.")
-		} else {
-			defer os.Remove(payloadBin)
+		fmt.Println("Locating payload.bin in ZIP archive...")
+		zipFile, offset, err := findPayloadBinOffset(filename)
+		if err != nil {
+			log.Fatalf("Failed to locate payload.bin: %v\n", err)
 		}
+		payloadFile = zipFile
+		payloadOffset = offset
+		fmt.Printf("Found payload.bin at offset: %d\n", offset)
 	}
-	fmt.Printf("payload.bin: %s\n", payloadBin)
+	
+	fmt.Printf("payload file: %s (offset: %d)\n", payloadFile, payloadOffset)
 
-	payload := NewPayload(payloadBin)
+	payload := NewPayload(payloadFile, payloadOffset)
 	if err := payload.Open(); err != nil {
 		log.Fatal(err)
 	}

--- a/payload.go
+++ b/payload.go
@@ -30,7 +30,8 @@ type request struct {
 
 // Payload is a new format for the Android OTA/Firmware update files since Android Oreo
 type Payload struct {
-	Filename string
+	Filename      string
+	PayloadOffset int64 // NEW: offset of payload.bin within the file (0 for raw .bin, >0 for ZIP)
 
 	file                 *os.File
 	header               *payloadHeader
@@ -64,6 +65,10 @@ type payloadHeader struct {
 }
 
 func (ph *payloadHeader) ReadFromPayload() error {
+	if _, err := ph.payload.file.Seek(ph.payload.PayloadOffset, 0); err != nil {
+		return err
+	}
+
 	buf := make([]byte, 4)
 	if _, err := ph.payload.file.Read(buf); err != nil {
 		return err
@@ -105,11 +110,12 @@ func (ph *payloadHeader) ReadFromPayload() error {
 	return nil
 }
 
-// NewPayload creates a new Payload struct
-func NewPayload(filename string) *Payload {
+// creates a new Payload struct
+func NewPayload(filename string, payloadOffset int64) *Payload {
 	payload := &Payload{
-		Filename:    filename,
-		concurrency: 4,
+		Filename:      filename,
+		PayloadOffset: payloadOffset,
+		concurrency:   4,
 	}
 
 	return payload
@@ -150,7 +156,8 @@ func (p *Payload) readManifest() (*chromeos_update_engine.DeltaArchiveManifest, 
 }
 
 func (p *Payload) readMetadataSignature() (*chromeos_update_engine.Signatures, error) {
-	if _, err := p.file.Seek(int64(p.header.Size+p.header.ManifestLen), 0); err != nil {
+	// Seek relative to PayloadOffset
+	if _, err := p.file.Seek(p.PayloadOffset+int64(p.header.Size+p.header.ManifestLen), 0); err != nil {
 		return nil, err
 	}
 
@@ -210,7 +217,9 @@ func (p *Payload) Init() error {
 
 func (p *Payload) readDataBlob(offset int64, length int64) ([]byte, error) {
 	buf := make([]byte, length)
-	n, err := p.file.ReadAt(buf, p.dataOffset+offset)
+	// Add PayloadOffset to account for ZIP offset
+	absoluteOffset := p.PayloadOffset + p.dataOffset + offset
+	n, err := p.file.ReadAt(buf, absoluteOffset)
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +253,8 @@ func (p *Payload) Extract(partition *chromeos_update_engine.PartitionUpdate, out
 		bar.Increment()
 
 		e := operation.DstExtents[0]
-		dataOffset := p.dataOffset + int64(operation.GetDataOffset())
+		// Add PayloadOffset to account for ZIP offset
+		dataOffset := p.PayloadOffset + p.dataOffset + int64(operation.GetDataOffset())
 		dataLength := int64(operation.GetDataLength())
 		_, err := out.Seek(int64(e.GetStartBlock())*blockSize, 0)
 		if err != nil {


### PR DESCRIPTION
Payload.bin is always stored in OTA files using the uncompressed method. There is no need to first extract it to a temporary file and then dump it. Instead, we can get the file offset and dump it directly, which saves time. This PR implements that change.