### PR TITLE
ci: add windows/arm64 goreleaser artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,5 +17,8 @@ jobs:
       - name: Build
         run: go build .
 
+      - name: Build amd64 v3
+        run: GOAMD64=v3 go build -o payload-dumper-go.v3 .
+
       - name: Test
         run: go test ./...

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -296,30 +296,62 @@ jobs:
           chmod +x scripts/prepare-gozstd-windows-arm64.sh
           ./scripts/prepare-gozstd-windows-arm64.sh
 
+      - id: goreleaser-args
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish }}" != "true" ]; then
+            echo "args=release --clean --snapshot --skip=publish" >> "$GITHUB_OUTPUT"
+            echo "level=info msg=\"goreleaser dry run\" publish=false"
+          else
+            echo "args=release --clean" >> "$GITHUB_OUTPUT"
+            echo "level=info msg=\"goreleaser publish run\" event=${{ github.event_name }}"
+          fi
+
       - uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
-          args: >-
-            release --clean
-            ${{ github.event_name == 'workflow_dispatch' && inputs.publish != true && '--snapshot --skip=publish' || '' }}
+          args: ${{ steps.goreleaser-args.outputs.args }}
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Verify Windows ARM64 artifact
+      - name: Verify release artifacts
         run: |
-          artifact=$(find dist -type f \( -name '*windows_arm64*' -o -name '*windows-arm64*' \) ! -name '*.json' | head -1)
-          if [ -z "$artifact" ]; then
+          echo "level=info msg=\"listing dist artifacts\""
+          find dist -type f -print | sort
+          missing=0
+          winarm=$(find dist -type f \( -name '*windows_arm64*' -o -name '*windows-arm64*' \) ! -name '*.json' | head -1)
+          if [ -z "$winarm" ]; then
             echo "level=error msg=\"windows/arm64 artifact missing\" dir=dist"
-            ls -la dist || true
-            find dist -type f -print || true
+            missing=1
+          else
+            echo "level=info msg=\"windows/arm64 artifact ready\" path=$winarm"
+            file "$winarm" || true
+            ls -lh "$winarm"
+            case "$winarm" in
+              *.tar.gz|*.tgz)
+                inner=$(tar -tzf "$winarm" | grep -E '\.exe$' | head -1 || true)
+                if [ -n "$inner" ]; then
+                  tmp=$(mktemp -d)
+                  tar -xzf "$winarm" -C "$tmp" "$inner"
+                  echo "level=info msg=\"windows/arm64 binary type\" path=$inner type=$(file -b "$tmp/$inner")"
+                  echo "$(file -b "$tmp/$inner")" | grep -qi 'aarch64\|arm64\|aa64'
+                fi
+                ;;
+            esac
+          fi
+          v3=$(find dist -type f \( -name '*amd64v3*' -o -name '*amd64_v3*' \) ! -name '*.json' | head -1)
+          if [ -z "$v3" ]; then
+            echo "level=error msg=\"amd64 v3 artifact missing\" dir=dist"
+            missing=1
+          else
+            echo "level=info msg=\"amd64 v3 artifact ready\" path=$v3"
+            ls -lh "$v3"
+          fi
+          if [ "$missing" -ne 0 ]; then
             exit 1
           fi
-          echo "level=info msg=\"windows/arm64 artifact ready\" path=$artifact"
-          file "$artifact" || true
-          ls -lh "$artifact"
 
       - uses: actions/upload-artifact@v7
-        if: github.event_name == 'workflow_dispatch' && inputs.publish != true
+        if: github.event_name == 'workflow_dispatch' && inputs.publish != 'true'
         with:
           name: dist
           path: dist/

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -335,13 +335,13 @@ jobs:
                 ;;
             esac
           fi
-          v3=$(find dist -type f \( -name '*amd64v3*' -o -name '*amd64_v3*' \) ! -name '*.json' | head -1)
-          if [ -z "$v3" ]; then
-            echo "level=error msg=\"amd64 v3 artifact missing\" dir=dist"
+          avx2=$(find dist -type f -name '*amd64_avx2*' ! -name '*.json' | head -1)
+          if [ -z "$avx2" ]; then
+            echo "level=error msg=\"amd64 avx2 artifact missing\" dir=dist"
             missing=1
           else
-            echo "level=info msg=\"amd64 v3 artifact ready\" path=$v3"
-            ls -lh "$v3"
+            echo "level=info msg=\"amd64 avx2 artifact ready\" path=$avx2"
+            ls -lh "$avx2"
           fi
           if [ "$missing" -ne 0 ]; then
             exit 1

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -84,9 +84,6 @@ jobs:
           path: /llvm-mingw
           key: llvm-mingw-20260616-ucrt-ubuntu-22.04-x86_64
 
-      - name: Add llvm-mingw to PATH
-        run: echo /llvm-mingw/bin >> "$GITHUB_PATH"
-
       - id: buildroots-cache
         uses: actions/cache/restore@v6
         with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "*"
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Create a GitHub Release. Leave off to build artifacts only."
+        type: boolean
+        default: false
 
 jobs:
   macos-sdk:
@@ -44,7 +50,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          dnf -y install autoconf bash clang cmake gettext-devel git glibc-{devel,static}.{i686,x86_64} golang libstdc++-static libtool libuuid-devel libxml2-devel llvm-devel make mingw{32,64}-{winpthreads,xz-libs}-static mingw{32,64}-gcc{-c++,} openssl-devel patch po4a xz-{devel,static}.{i686,x86_64}
+          dnf -y install aria2 autoconf bash clang cmake file gettext-devel git glibc-{devel,static}.{i686,x86_64} golang libstdc++-static libtool libuuid-devel libxml2-devel llvm-devel make mingw{32,64}-{winpthreads,xz-libs}-static mingw{32,64}-gcc{-c++,} openssl-devel patch po4a xz-{devel,static}.{i686,x86_64}
           dnf -y install 'dnf-command(download)'
           dnf download --source xz-devel
           rpm -ivh *.src.rpm
@@ -52,6 +58,34 @@ jobs:
 
       - id: xz-version
         run: echo "version=$(basename $HOME/rpmbuild/SOURCES/xz-*.tar.gz .tar.gz)" >> "$GITHUB_OUTPUT"
+
+      - id: llvm-mingw-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: /llvm-mingw
+          key: llvm-mingw-20260616-ucrt-ubuntu-22.04-x86_64
+
+      - name: Install llvm-mingw
+        if: steps.llvm-mingw-cache.outputs.cache-hit != 'true'
+        run: |
+          echo "level=info msg=\"downloading llvm-mingw\" version=20260616"
+          mkdir -p /tmp/llvm-mingw-dl /llvm-mingw
+          aria2c -x 16 -s 16 -d /tmp/llvm-mingw-dl -o llvm-mingw.tar.xz \
+            https://github.com/mstorsjo/llvm-mingw/releases/download/20260616/llvm-mingw-20260616-ucrt-ubuntu-22.04-x86_64.tar.xz
+          tar -xJf /tmp/llvm-mingw-dl/llvm-mingw.tar.xz -C /tmp/llvm-mingw-dl
+          src=$(echo /tmp/llvm-mingw-dl/llvm-mingw-*)
+          cp -a "$src"/. /llvm-mingw/
+          rm -rf /tmp/llvm-mingw-dl
+          echo "level=info msg=\"installed llvm-mingw\" prefix=/llvm-mingw"
+
+      - uses: actions/cache/save@v6
+        if: always() && steps.llvm-mingw-cache.outputs.cache-hit != 'true'
+        with:
+          path: /llvm-mingw
+          key: llvm-mingw-20260616-ucrt-ubuntu-22.04-x86_64
+
+      - name: Add llvm-mingw to PATH
+        run: echo /llvm-mingw/bin >> "$GITHUB_PATH"
 
       - id: buildroots-cache
         uses: actions/cache/restore@v6
@@ -61,7 +95,8 @@ jobs:
             /linux-aarch64-buildroot/sys-root
             /darwin-amd64-buildroot/sys-root
             /darwin-aarch64-buildroot/sys-root
-          key: ${{ runner.os }}-buildroots-${{ steps.xz-version.outputs.version }}
+            /windows-arm64-buildroot/sys-root
+          key: ${{ runner.os }}-buildroots-${{ steps.xz-version.outputs.version }}-winarm64
 
       - name: Setup cross compile environment for Linux ARMv7
         env:
@@ -175,6 +210,53 @@ jobs:
             popd
           fi
 
+      - name: Setup cross compile environment for Windows ARM64
+        env:
+          CC: aarch64-w64-mingw32-gcc
+          CXX: aarch64-w64-mingw32-g++
+        run: |
+          export PATH=/llvm-mingw/bin:$PATH
+          echo "level=info msg=\"checking llvm-mingw compiler\" cc=$(command -v "$CC")"
+          "$CC" --version
+          if [ ! -f /windows-arm64-buildroot/sys-root/lib/liblzma.a ]; then
+            echo "level=info msg=\"building liblzma for windows/arm64\""
+            mkdir -p /windows-arm64-buildroot
+            pushd /windows-arm64-buildroot
+            tar -xvf $HOME/rpmbuild/SOURCES/xz-*.tar.gz
+            pushd $(basename $HOME/rpmbuild/SOURCES/xz-*.tar.gz .tar.gz)
+            ./autogen.sh
+            ./configure --host=aarch64-w64-mingw32 --prefix=/windows-arm64-buildroot/sys-root --enable-shared=no --disable-xz --disable-xzdec --disable-lzmadec --disable-lzmainfo --disable-scripts --disable-doc
+            make -j$(nproc) install
+            popd
+            popd
+            echo "level=info msg=\"installed liblzma\" prefix=/windows-arm64-buildroot/sys-root"
+          else
+            echo "level=info msg=\"reusing cached liblzma\" prefix=/windows-arm64-buildroot/sys-root"
+          fi
+          if [ ! -f /windows-arm64-buildroot/sys-root/lib/libzstd.a ]; then
+            echo "level=info msg=\"building libzstd for windows/arm64\" version=1.5.7"
+            mkdir -p /tmp/zstd-dl /windows-arm64-buildroot/sys-root/lib
+            aria2c -x 16 -s 16 -d /tmp/zstd-dl -o zstd.tar.gz \
+              https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz
+            tar -xzf /tmp/zstd-dl/zstd.tar.gz -C /tmp/zstd-dl
+            make -C /tmp/zstd-dl/zstd-1.5.7/lib \
+              CC=aarch64-w64-mingw32-gcc \
+              AR=aarch64-w64-mingw32-ar \
+              RANLIB=aarch64-w64-mingw32-ranlib \
+              TARGET_SYSTEM=Windows \
+              OS=Windows_NT \
+              UNAME=Windows \
+              UNAME_TARGET_SYSTEM=Windows \
+              ZSTD_LEGACY_SUPPORT=0 \
+              ZSTD_NO_ASM=1 \
+              libzstd.a
+            cp -f /tmp/zstd-dl/zstd-1.5.7/lib/libzstd.a /windows-arm64-buildroot/sys-root/lib/libzstd.a
+            rm -rf /tmp/zstd-dl
+            echo "level=info msg=\"installed libzstd\" path=/windows-arm64-buildroot/sys-root/lib/libzstd.a"
+          else
+            echo "level=info msg=\"reusing cached libzstd\" path=/windows-arm64-buildroot/sys-root/lib/libzstd.a"
+          fi
+
       - uses: actions/cache/save@v6
         if: always() && steps.buildroots-cache.outputs.cache-hit != 'true'
         with:
@@ -183,7 +265,8 @@ jobs:
             /linux-aarch64-buildroot/sys-root
             /darwin-amd64-buildroot/sys-root
             /darwin-aarch64-buildroot/sys-root
-          key: ${{ runner.os }}-buildroots-${{ steps.xz-version.outputs.version }}
+            /windows-arm64-buildroot/sys-root
+          key: ${{ runner.os }}-buildroots-${{ steps.xz-version.outputs.version }}-winarm64
 
       - uses: actions/checkout@v7
         with:
@@ -202,12 +285,44 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      - name: Ensure windows/arm64 libzstd
+        env:
+          CC: aarch64-w64-mingw32-gcc
+          AR: aarch64-w64-mingw32-ar
+          RANLIB: aarch64-w64-mingw32-ranlib
+          WINDOWS_ARM64_SYSROOT: /windows-arm64-buildroot/sys-root
+        run: |
+          export PATH=/llvm-mingw/bin:$PATH
+          chmod +x scripts/prepare-gozstd-windows-arm64.sh
+          ./scripts/prepare-gozstd-windows-arm64.sh
+
       - uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
-          args: release --clean
+          args: >-
+            release --clean
+            ${{ github.event_name == 'workflow_dispatch' && inputs.publish != true && '--snapshot --skip=publish' || '' }}
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Verify Windows ARM64 artifact
+        run: |
+          artifact=$(find dist -type f \( -name '*windows_arm64*' -o -name '*windows-arm64*' \) ! -name '*.json' | head -1)
+          if [ -z "$artifact" ]; then
+            echo "level=error msg=\"windows/arm64 artifact missing\" dir=dist"
+            ls -la dist || true
+            find dist -type f -print || true
+            exit 1
+          fi
+          echo "level=info msg=\"windows/arm64 artifact ready\" path=$artifact"
+          file "$artifact" || true
+          ls -lh "$artifact"
+
+      - uses: actions/upload-artifact@v7
+        if: github.event_name == 'workflow_dispatch' && inputs.publish != true
+        with:
+          name: dist
+          path: dist/
 
       - uses: actions/cache/save@v6
         if: always() && steps.go-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/windows-arm64.yml
+++ b/.github/workflows/windows-arm64.yml
@@ -1,0 +1,118 @@
+name: windows-arm64
+
+on:
+  pull_request:
+    paths:
+      - ".goreleaser.yml"
+      - ".github/workflows/goreleaser.yml"
+      - ".github/workflows/windows-arm64.yml"
+      - "scripts/prepare-gozstd-windows-arm64.sh"
+      - "go.mod"
+      - "go.sum"
+      - "**/*.go"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: fedora:41
+    env:
+      GOTOOLCHAIN: auto
+      GOPROXY: https://proxy.golang.org,direct
+      GOSUMDB: sum.golang.org
+
+    steps:
+      - name: Install dependencies
+        run: dnf -y install aria2 autoconf automake file gettext-devel git golang libtool make
+
+      - uses: actions/checkout@v7
+
+      - name: Add $GITHUB_WORKSPACE to git safe.directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - id: llvm-mingw-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: /llvm-mingw
+          key: llvm-mingw-20260616-ucrt-ubuntu-22.04-x86_64
+
+      - name: Install llvm-mingw
+        if: steps.llvm-mingw-cache.outputs.cache-hit != 'true'
+        run: |
+          echo "level=info msg=\"downloading llvm-mingw\" version=20260616"
+          mkdir -p /tmp/llvm-mingw-dl /llvm-mingw
+          aria2c -x 16 -s 16 -d /tmp/llvm-mingw-dl -o llvm-mingw.tar.xz \
+            https://github.com/mstorsjo/llvm-mingw/releases/download/20260616/llvm-mingw-20260616-ucrt-ubuntu-22.04-x86_64.tar.xz
+          tar -xJf /tmp/llvm-mingw-dl/llvm-mingw.tar.xz -C /tmp/llvm-mingw-dl
+          src=$(echo /tmp/llvm-mingw-dl/llvm-mingw-*)
+          cp -a "$src"/. /llvm-mingw/
+          rm -rf /tmp/llvm-mingw-dl
+          echo "level=info msg=\"installed llvm-mingw\" prefix=/llvm-mingw"
+
+      - uses: actions/cache/save@v6
+        if: always() && steps.llvm-mingw-cache.outputs.cache-hit != 'true'
+        with:
+          path: /llvm-mingw
+          key: llvm-mingw-20260616-ucrt-ubuntu-22.04-x86_64
+
+      - id: sysroot-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: /windows-arm64-buildroot/sys-root
+          key: ${{ runner.os }}-windows-arm64-sysroot-xz-5.6.4-zstd-1.5.7
+
+      - name: Build Windows ARM64 sysroot
+        env:
+          CC: aarch64-w64-mingw32-gcc
+          CXX: aarch64-w64-mingw32-g++
+          WINDOWS_ARM64_SYSROOT: /windows-arm64-buildroot/sys-root
+        run: |
+          export PATH=/llvm-mingw/bin:$PATH
+          echo "level=info msg=\"checking llvm-mingw compiler\" cc=$(command -v "$CC")"
+          "$CC" --version
+          if [ ! -f /windows-arm64-buildroot/sys-root/lib/liblzma.a ]; then
+            echo "level=info msg=\"building liblzma for windows/arm64\" version=5.6.4"
+            mkdir -p /tmp/xz-dl /windows-arm64-buildroot
+            aria2c -x 16 -s 16 -d /tmp/xz-dl -o xz.tar.gz \
+              https://github.com/tukaani-project/xz/releases/download/v5.6.4/xz-5.6.4.tar.gz
+            tar -xzf /tmp/xz-dl/xz.tar.gz -C /tmp/xz-dl
+            pushd /tmp/xz-dl/xz-5.6.4
+            ./configure --host=aarch64-w64-mingw32 --prefix=/windows-arm64-buildroot/sys-root --enable-shared=no --disable-xz --disable-xzdec --disable-lzmadec --disable-lzmainfo --disable-scripts --disable-doc
+            make -j"$(nproc)" install
+            popd
+            rm -rf /tmp/xz-dl
+          fi
+          chmod +x scripts/prepare-gozstd-windows-arm64.sh
+          ./scripts/prepare-gozstd-windows-arm64.sh
+
+      - uses: actions/cache/save@v6
+        if: always() && steps.sysroot-cache.outputs.cache-hit != 'true'
+        with:
+          path: /windows-arm64-buildroot/sys-root
+          key: ${{ runner.os }}-windows-arm64-sysroot-xz-5.6.4-zstd-1.5.7
+
+      - uses: goreleaser/goreleaser-action@v7
+        with:
+          version: latest
+          args: build --id build-windows-arm64 --snapshot --clean --skip=validate
+        env:
+          PATH: /llvm-mingw/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+      - name: Verify Windows ARM64 binary
+        run: |
+          binary=$(find dist -type f -name '*.exe' | head -1)
+          if [ -z "$binary" ]; then
+            echo "level=error msg=\"windows/arm64 exe missing\" dir=dist"
+            find dist -type f -print || true
+            exit 1
+          fi
+          echo "level=info msg=\"windows/arm64 binary ready\" path=$binary"
+          file "$binary"
+          ls -lh "$binary"
+          echo "$binary" | grep -q arm64
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: payload-dumper-go-windows-arm64
+          path: dist/
+          if-no-files-found: error

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,9 @@ builds:
       - windows
     goarch:
       - amd64
+    goamd64:
+      - v1
+      - v3
     ldflags:
       - '-extldflags "-static -s -w"'
   - id: build-windows-arm64
@@ -35,6 +38,9 @@ builds:
       - linux
     goarch:
       - amd64
+    goamd64:
+      - v1
+      - v3
     ldflags:
       - '-extldflags "-static -s -w"'
   - id: build-linux-armv7
@@ -74,6 +80,9 @@ builds:
       - darwin
     goarch:
       - amd64
+    goamd64:
+      - v1
+      - v3
   - id: build-darwin-arm64
     env:
       - CC=oa64-clang

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,8 +9,8 @@ env:
 builds:
   - id: build-windows-amd64
     env:
-      - CC=x86_64-w64-mingw32-gcc
-      - CXX=x86_64-w64-mingw32-g++
+      - CC=/usr/bin/x86_64-w64-mingw32-gcc
+      - CXX=/usr/bin/x86_64-w64-mingw32-g++
     goos:
       - windows
     goarch:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,19 @@ builds:
       - amd64
     ldflags:
       - '-extldflags "-static -s -w"'
+  - id: build-windows-arm64
+    env:
+      - CC=aarch64-w64-mingw32-gcc
+      - CXX=aarch64-w64-mingw32-g++
+      - CGO_CFLAGS=-I/windows-arm64-buildroot/sys-root/include
+      - 'CGO_LDFLAGS=-L/windows-arm64-buildroot/sys-root/lib -lzstd'
+      - PATH=/llvm-mingw/bin:$PATH
+    goos:
+      - windows
+    goarch:
+      - arm64
+    ldflags:
+      - '-extldflags "-static -s -w"'
   - id: build-linux-amd64
     goos:
       - linux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,8 @@ version: 2
 checksum:
   name_template: "{{ .ProjectName }}_sha256checksums.txt"
   algorithm: sha256
+archives:
+  - name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ if eq .Amd64 "v3" }}_avx2{{ end }}'
 release:
   prerelease: auto
 env:

--- a/scripts/prepare-gozstd-windows-arm64.sh
+++ b/scripts/prepare-gozstd-windows-arm64.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  local level="$1"
+  shift
+  printf 'ts=%s level=%s msg="%s" %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$level" "$1" "${2:-}"
+}
+
+die() {
+  log error "$1" "${2:-}"
+  exit 1
+}
+
+CC="${CC:-aarch64-w64-mingw32-gcc}"
+AR="${AR:-aarch64-w64-mingw32-ar}"
+RANLIB="${RANLIB:-aarch64-w64-mingw32-ranlib}"
+SYSROOT="${WINDOWS_ARM64_SYSROOT:-/windows-arm64-buildroot/sys-root}"
+OUT="$SYSROOT/lib/libzstd.a"
+
+command -v "$CC" >/dev/null 2>&1 || die "missing C compiler" "cc=$CC"
+command -v "$AR" >/dev/null 2>&1 || die "missing archiver" "ar=$AR"
+
+if [ -f "$OUT" ]; then
+  log info "libzstd already present" "path=$OUT"
+  exit 0
+fi
+
+if [ -n "${ZSTD_SRC:-}" ]; then
+  zstd_root="$ZSTD_SRC"
+else
+  command -v go >/dev/null 2>&1 || die "missing go toolchain and ZSTD_SRC" ""
+  log info "downloading gozstd module for vendored zstd" "module=github.com/valyala/gozstd"
+  go mod download github.com/valyala/gozstd
+  zstd_root="$(go list -m -f '{{.Dir}}' github.com/valyala/gozstd)/zstd"
+fi
+
+[ -d "$zstd_root/lib" ] || die "zstd lib directory not found" "dir=$zstd_root/lib"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+cp -aR "$zstd_root" "$work/zstd"
+
+log info "building libzstd for windows/arm64" "cc=$CC ar=$AR src=$zstd_root"
+make -C "$work/zstd/lib" \
+  CC="$CC" \
+  AR="$AR" \
+  RANLIB="$RANLIB" \
+  TARGET_SYSTEM=Windows \
+  OS=Windows_NT \
+  UNAME=Windows \
+  UNAME_TARGET_SYSTEM=Windows \
+  ZSTD_LEGACY_SUPPORT=0 \
+  ZSTD_NO_ASM=1 \
+  libzstd.a
+
+[ -f "$work/zstd/lib/libzstd.a" ] || die "libzstd.a was not produced" "work=$work/zstd/lib"
+
+mkdir -p "$SYSROOT/lib"
+cp -f "$work/zstd/lib/libzstd.a" "$OUT"
+[ -f "$OUT" ] || die "failed to install libzstd.a" "path=$OUT"
+log info "installed libzstd" "path=$OUT"


### PR DESCRIPTION
## Summary
- Add a `windows/arm64` goreleaser build so release archives include a native Windows on ARM binary.
- Cross-compile with llvm-mingw (GCC mingw cannot target Windows ARM64) and a cached `liblzma` + `libzstd` sysroot. `gozstd` has no prebuilt `windows/arm64` `.a`, so CI builds `libzstd.a` with `ZSTD_NO_ASM=1` and links it via `CGO_LDFLAGS`.
- Also ship extra `GOAMD64=v3` artifacts for linux/windows/darwin amd64. Default `v1` binaries stay as-is (`linux_amd64` names unchanged). v3 archives are named `*_amd64_avx2.tar.gz`.
- PR CI builds only the windows/arm64 target (`goreleaser build --id build-windows-arm64 --snapshot --skip=validate`) and uploads the artifact. Tag pushes still use the full goreleaser pipeline. `workflow_dispatch` on `goreleaser.yml` defaults to `--snapshot --skip=publish`.

Closes #63

## GOAMD64=v3 research
Issue #63 reported ~38.8% faster extract on a 7950X + RAM disk. That flag is real (Go 1.18+, AVX2/BMI2/FMA), but 38% is an optimistic upper bound for *this* repo:

- Official wiki: higher `GOAMD64` *may* help; benchmark the actual workload.
- `crypto/sha256` already picks SHA-NI/AVX2 at **runtime** on a v1 binary.
- xz/zstd here are CGO (`liblzma`, prebuilt `gozstd` `.a`). `GOAMD64` does not rebuild those C libs.
- Where v3 *can* help: pure-Go paths (`bspatch`, `compress/bzip2`, extent loops). Incremental OTAs more than full xz/zstd dumps.
- v3 binaries will not start on pre-Haswell / pre-Excavator CPUs (and some VMs without AVX2). That is why v1 stays the default download.

## Test plan
- [x] Local `GOOS=windows GOARCH=arm64` CGO build with llvm-mingw + sysroot
- [x] `windows-arm64` workflow produces `payload-dumper-go.exe` under a `*windows_arm64*` path
- [x] `build` workflow compiles with `GOAMD64=v3`
- [x] Full goreleaser dry-run via `workflow_dispatch` (`publish=false`): snapshot artifacts only, no GitHub Release. Confirmed `windows_arm64` is PE32+ Aarch64. Archive names for the AVX2 builds are now `*_amd64_avx2.tar.gz`. Previous dry-run: https://github.com/ssut/payload-dumper-go/actions/runs/31773665793